### PR TITLE
Fix Unicode output (#64)

### DIFF
--- a/compiler/base/Dockerfile
+++ b/compiler/base/Dockerfile
@@ -41,6 +41,13 @@ RUN /playground/attach_notice.sh /playground/security_notice.txt /etc/passwd && 
 COPY --chown=playground --from=dependencies target/dependency /playground/dependencies
 COPY --chown=playground --from=jre jre /playground/jre
 
+# Install locale for proper Unicode support
+RUN apt-get update && \
+    apt-get -y install locales && \
+    sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
+    locale-gen
+ENV LANG en_US.UTF-8
+
 USER playground
 ENV USER=playground
 ENV PATH=/playground/jre/bin:$PATH

--- a/ui/src/sandbox.rs
+++ b/ui/src/sandbox.rs
@@ -680,6 +680,28 @@ mod test {
     }
 
     #[tokio::test]
+    async fn unicode() {
+        let _singleton = one_test_at_a_time();
+        let code = r#"
+            public class Main {
+                public static void main(String[] args) {
+                    System.out.println("Привет, мир!");
+                }
+            }
+        "#;
+
+        let req = ExecuteRequest {
+            code: code.to_string(),
+            ..ExecuteRequest::default()
+        };
+
+        let sb = Sandbox::new().await.expect("Unable to create sandbox");
+        let resp = sb.execute(&req).await.expect("Unable to execute code");
+
+        assert!(resp.stdout.contains("Привет, мир!"));
+    }
+
+    #[tokio::test]
     async fn network_connections_are_disabled() {
         let _singleton = one_test_at_a_time();
         let code = r#"


### PR DESCRIPTION
This PR adds a `en_US.UTF-8` locale to the Docker containers and sets it as the current locale so that Java properly outputs Unicode.